### PR TITLE
Update team.faabBalance to be nullable

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -9,4 +9,6 @@ dependencies {
     implementation("org.quartz-scheduler:quartz:2.3.0")
     implementation("com.github.scribejava:scribejava-apis:6.0.0")
     implementation("org.jsoup:jsoup:1.7.2")
+
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.5.1'
 }

--- a/bot/src/main/kotlin/bot/transformers/MatchUpDataTransformer.kt
+++ b/bot/src/main/kotlin/bot/transformers/MatchUpDataTransformer.kt
@@ -26,11 +26,11 @@ fun Observable<Pair<Team, Team>>.convertToMatchUpMessage(): Observable<Message> 
         val teams = it.toList()
         for (team: Team in teams) {
             teamDataBuilder.append("Team: ${team.name}\\nWin Probability: ${team.winProbability}%\\nProjected Points: ${team.projectedPoints}")
-            if (team.faabBalance != null) {
-                teamDataBuilder.append("\\nFAAB: ${team.faabBalance}")
-            } else {
-                teamDataBuilder.append("\\nWaiver Priority: ${team.waiverPriority}")
-            }
+            teamDataBuilder.append(
+                team.faabBalance?.let { balance ->
+                    teamDataBuilder.append("\\nFAAB: $balance")
+                } ?: teamDataBuilder.append("\\nWaiver Priority: ${team.waiverPriority}")
+            )
             teamDataBuilder.append("\\n\\n")
         }
 

--- a/bot/src/main/kotlin/bot/transformers/MatchUpDataTransformer.kt
+++ b/bot/src/main/kotlin/bot/transformers/MatchUpDataTransformer.kt
@@ -25,7 +25,13 @@ fun Observable<Pair<Team, Team>>.convertToMatchUpMessage(): Observable<Message> 
 
         val teams = it.toList()
         for (team: Team in teams) {
-            teamDataBuilder.append("Team: ${team.name}\\nWin Probability: ${team.winProbability}%\\nProjected Points: ${team.projectedPoints}\\nWaiver Priority: ${team.waiverPriority}\\nFAAB: ${team.faabBalance}\\n\\n")
+            teamDataBuilder.append("Team: ${team.name}\\nWin Probability: ${team.winProbability}%\\nProjected Points: ${team.projectedPoints}")
+            if (team.faabBalance != null) {
+                teamDataBuilder.append("\\nFAAB: ${team.faabBalance}")
+            } else {
+                teamDataBuilder.append("\\nWaiver Priority: ${team.waiverPriority}")
+            }
+            teamDataBuilder.append("\\n\\n")
         }
 
         val finalMessage = teamDataBuilder.toString().trim()
@@ -59,7 +65,7 @@ private fun generateTeamData(team: Element): Team {
     val id = team.select("team_id").text().toInt()
     val name = team.select("name").text()
     val waiverPriority = team.select("waiver_priority").text().toInt()
-    val faabBalance = team.select("faab_balance").text().toInt()
+    val faabBalance = team.select("faab_balance").text().toIntOrNull()
     val numberOfMoves = team.select("number_of_moves").text().toInt()
     val numberOfTrades = team.select("number_of_trades").text().toInt()
     val winProbability = team.select("win_probability").text().toDouble() * 100
@@ -83,7 +89,7 @@ data class Team(
     val name: String,
     val id: Int,
     val waiverPriority: Int,
-    val faabBalance: Int,
+    val faabBalance: Int?,
     val numberOfMoves: Int,
     val numberOfTrades: Int,
     val winProbability: Double,

--- a/bot/src/test/bot/transformers/MatchUpDataTransformerKtTest.kt
+++ b/bot/src/test/bot/transformers/MatchUpDataTransformerKtTest.kt
@@ -1,0 +1,343 @@
+package bot.transformers
+
+import bot.messaging_services.Message
+import io.reactivex.observers.TestObserver
+import io.reactivex.schedulers.TestScheduler
+import io.reactivex.subjects.PublishSubject
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+internal class MatchUpDataTransformerKtTest {
+
+    private lateinit var testScheduler: TestScheduler
+
+    private lateinit var testPublishSubject: PublishSubject<Document>
+
+    private lateinit var faabDocument: Document
+    private lateinit var nonFaabDocument: Document
+
+    @BeforeEach
+    fun setUp() {
+        testScheduler = TestScheduler()
+        testPublishSubject = PublishSubject.create()
+
+        faabDocument = Jsoup.parse(
+            "<matchup>\n" +
+                    "\t<week> 16 </week>\n" +
+                    "\t<week_start> 2018-12-18 </week_start>\n" +
+                    "\t<week_end> 2018-12-24 </week_end>\n" +
+                    "\t<status> postevent </status>\n" +
+                    "\t<is_playoffs> 1 </is_playoffs>\n" +
+                    "\t<is_consolation> 0 </is_consolation>\n" +
+                    "\t<is_matchup_recap_available> 1 </is_matchup_recap_available>\n" +
+                    "\t<matchup_grades>\n" +
+                    "\t\t<matchup_grade>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.1 </team_key>\n" +
+                    "\t\t\t<grade> B </grade>\n" +
+                    "\t\t</matchup_grade>\n" +
+                    "\t\t<matchup_grade>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.3 </team_key>\n" +
+                    "\t\t\t<grade> A+ </grade>\n" +
+                    "\t\t</matchup_grade>\n" +
+                    "\t</matchup_grades>\n" +
+                    "\t<is_tied> 0 </is_tied>\n" +
+                    "\t<winner_team_key> 380.l.1269264.t.3 </winner_team_key>\n" +
+                    "\t<teams count=\"2\">\n" +
+                    "\t\t<team>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.1 </team_key>\n" +
+                    "\t\t\t<team_id> 1 </team_id>\n" +
+                    "\t\t\t<name> TEST TEAM 1 </name>\n" +
+                    "\t\t\t<team_logos>\n" +
+                    "\t\t\t\t<team_logo>\n" +
+                    "\t\t\t\t\t<size> large </size>\n" +
+                    "\t\t\t\t</team_logo>\n" +
+                    "\t\t\t</team_logos>\n" +
+                    "\t\t\t<division_id> 1 </division_id>\n" +
+                    "\t\t\t<waiver_priority> 9 </waiver_priority>\n" +
+                    "\t\t\t<faab_balance> 17 </faab_balance>\n" +
+                    "\t\t\t<number_of_moves> 41 </number_of_moves>\n" +
+                    "\t\t\t<number_of_trades> 0 </number_of_trades>\n" +
+                    "\t\t\t<roster_adds>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<coverage_value> 17 </coverage_value>\n" +
+                    "\t\t\t\t<value> 0 </value>\n" +
+                    "\t\t\t</roster_adds>\n" +
+                    "\t\t\t<clinched_playoffs> 1 </clinched_playoffs>\n" +
+                    "\t\t\t<league_scoring_type> head </league_scoring_type>\n" +
+                    "\t\t\t<draft_position> 7 </draft_position>\n" +
+                    "\t\t\t<has_draft_grade> 1 </has_draft_grade>\n" +
+                    "\t\t\t<draft_grade> B </draft_grade>\n" +
+                    "\t\t\t<managers>\n" +
+                    "\t\t\t\t<manager>\n" +
+                    "\t\t\t\t\t<manager_id> 1 </manager_id>\n" +
+                    "\t\t\t\t\t<nickname> Matt F </nickname>\n" +
+                    "\t\t\t\t\t<is_commissioner> 1 </is_commissioner>\n" +
+                    "\t\t\t\t</manager>\n" +
+                    "\t\t\t</managers>\n" +
+                    "\t\t\t<win_probability> 0 </win_probability>\n" +
+                    "\t\t\t<team_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 129.86 </total>\n" +
+                    "\t\t\t</team_points>\n" +
+                    "\t\t\t<team_projected_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 138.11 </total>\n" +
+                    "\t\t\t</team_projected_points>\n" +
+                    "\t\t</team>\n" +
+                    "\t\t<team>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.3 </team_key>\n" +
+                    "\t\t\t<team_id> 3 </team_id>\n" +
+                    "\t\t\t<name> TEST TEAM 2 </name>\n" +
+                    "\t\t\t<team_logos>\n" +
+                    "\t\t\t\t<team_logo>\n" +
+                    "\t\t\t\t\t<size> large </size>\n" +
+                    "\t\t\t\t</team_logo>\n" +
+                    "\t\t\t</team_logos>\n" +
+                    "\t\t\t<division_id> 1 </division_id>\n" +
+                    "\t\t\t<waiver_priority> 6 </waiver_priority>\n" +
+                    "\t\t\t<faab_balance> 100 </faab_balance>\n" +
+                    "\t\t\t<number_of_moves> 9 </number_of_moves>\n" +
+                    "\t\t\t<number_of_trades> 0 </number_of_trades>\n" +
+                    "\t\t\t<roster_adds>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<coverage_value> 17 </coverage_value>\n" +
+                    "\t\t\t\t<value> 0 </value>\n" +
+                    "\t\t\t</roster_adds>\n" +
+                    "\t\t\t<clinched_playoffs> 1 </clinched_playoffs>\n" +
+                    "\t\t\t<league_scoring_type> head </league_scoring_type>\n" +
+                    "\t\t\t<draft_position> 8 </draft_position>\n" +
+                    "\t\t\t<has_draft_grade> 1 </has_draft_grade>\n" +
+                    "\t\t\t<draft_grade> B </draft_grade>\n" +
+                    "\t\t\t<managers>\n" +
+                    "\t\t\t\t<manager>\n" +
+                    "\t\t\t\t\t<manager_id> 3 </manager_id>\n" +
+                    "\t\t\t\t\t<nickname> Sean </nickname>\n" +
+                    "\t\t\t\t</manager>\n" +
+                    "\t\t\t</managers>\n" +
+                    "\t\t\t<win_probability> 1 </win_probability>\n" +
+                    "\t\t\t<team_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 208.52 </total>\n" +
+                    "\t\t\t</team_points>\n" +
+                    "\t\t\t<team_projected_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 131.00 </total>\n" +
+                    "\t\t\t</team_projected_points>\n" +
+                    "\t\t</team>\n" +
+                    "\t</teams>\n" +
+                    "</matchup>"
+        )
+
+        nonFaabDocument = Jsoup.parse(
+            "<matchup>\n" +
+                    "\t<week> 16 </week>\n" +
+                    "\t<week_start> 2018-12-18 </week_start>\n" +
+                    "\t<week_end> 2018-12-24 </week_end>\n" +
+                    "\t<status> postevent </status>\n" +
+                    "\t<is_playoffs> 1 </is_playoffs>\n" +
+                    "\t<is_consolation> 0 </is_consolation>\n" +
+                    "\t<is_matchup_recap_available> 1 </is_matchup_recap_available>\n" +
+                    "\t<matchup_grades>\n" +
+                    "\t\t<matchup_grade>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.1 </team_key>\n" +
+                    "\t\t\t<grade> B </grade>\n" +
+                    "\t\t</matchup_grade>\n" +
+                    "\t\t<matchup_grade>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.3 </team_key>\n" +
+                    "\t\t\t<grade> A+ </grade>\n" +
+                    "\t\t</matchup_grade>\n" +
+                    "\t</matchup_grades>\n" +
+                    "\t<is_tied> 0 </is_tied>\n" +
+                    "\t<winner_team_key> 380.l.1269264.t.3 </winner_team_key>\n" +
+                    "\t<teams count=\"2\">\n" +
+                    "\t\t<team>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.1 </team_key>\n" +
+                    "\t\t\t<team_id> 1 </team_id>\n" +
+                    "\t\t\t<name> TEST TEAM 1 </name>\n" +
+                    "\t\t\t<team_logos>\n" +
+                    "\t\t\t\t<team_logo>\n" +
+                    "\t\t\t\t\t<size> large </size>\n" +
+                    "\t\t\t\t</team_logo>\n" +
+                    "\t\t\t</team_logos>\n" +
+                    "\t\t\t<division_id> 1 </division_id>\n" +
+                    "\t\t\t<waiver_priority> 9 </waiver_priority>\n" +
+                    "\t\t\t<number_of_moves> 41 </number_of_moves>\n" +
+                    "\t\t\t<number_of_trades> 0 </number_of_trades>\n" +
+                    "\t\t\t<roster_adds>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<coverage_value> 17 </coverage_value>\n" +
+                    "\t\t\t\t<value> 0 </value>\n" +
+                    "\t\t\t</roster_adds>\n" +
+                    "\t\t\t<clinched_playoffs> 1 </clinched_playoffs>\n" +
+                    "\t\t\t<league_scoring_type> head </league_scoring_type>\n" +
+                    "\t\t\t<draft_position> 7 </draft_position>\n" +
+                    "\t\t\t<has_draft_grade> 1 </has_draft_grade>\n" +
+                    "\t\t\t<draft_grade> B </draft_grade>\n" +
+                    "\t\t\t<managers>\n" +
+                    "\t\t\t\t<manager>\n" +
+                    "\t\t\t\t\t<manager_id> 1 </manager_id>\n" +
+                    "\t\t\t\t\t<nickname> Matt F </nickname>\n" +
+                    "\t\t\t\t\t<is_commissioner> 1 </is_commissioner>\n" +
+                    "\t\t\t\t</manager>\n" +
+                    "\t\t\t</managers>\n" +
+                    "\t\t\t<win_probability> 0 </win_probability>\n" +
+                    "\t\t\t<team_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 129.86 </total>\n" +
+                    "\t\t\t</team_points>\n" +
+                    "\t\t\t<team_projected_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 138.11 </total>\n" +
+                    "\t\t\t</team_projected_points>\n" +
+                    "\t\t</team>\n" +
+                    "\t\t<team>\n" +
+                    "\t\t\t<team_key> 380.l.1269264.t.3 </team_key>\n" +
+                    "\t\t\t<team_id> 3 </team_id>\n" +
+                    "\t\t\t<name> TEST TEAM 2 </name>\n" +
+                    "\t\t\t<team_logos>\n" +
+                    "\t\t\t\t<team_logo>\n" +
+                    "\t\t\t\t\t<size> large </size>\n" +
+                    "\t\t\t\t</team_logo>\n" +
+                    "\t\t\t</team_logos>\n" +
+                    "\t\t\t<division_id> 1 </division_id>\n" +
+                    "\t\t\t<waiver_priority> 6 </waiver_priority>\n" +
+                    "\t\t\t<number_of_moves> 9 </number_of_moves>\n" +
+                    "\t\t\t<number_of_trades> 0 </number_of_trades>\n" +
+                    "\t\t\t<roster_adds>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<coverage_value> 17 </coverage_value>\n" +
+                    "\t\t\t\t<value> 0 </value>\n" +
+                    "\t\t\t</roster_adds>\n" +
+                    "\t\t\t<clinched_playoffs> 1 </clinched_playoffs>\n" +
+                    "\t\t\t<league_scoring_type> head </league_scoring_type>\n" +
+                    "\t\t\t<draft_position> 8 </draft_position>\n" +
+                    "\t\t\t<has_draft_grade> 1 </has_draft_grade>\n" +
+                    "\t\t\t<draft_grade> B </draft_grade>\n" +
+                    "\t\t\t<managers>\n" +
+                    "\t\t\t\t<manager>\n" +
+                    "\t\t\t\t\t<manager_id> 3 </manager_id>\n" +
+                    "\t\t\t\t\t<nickname> Sean </nickname>\n" +
+                    "\t\t\t\t</manager>\n" +
+                    "\t\t\t</managers>\n" +
+                    "\t\t\t<win_probability> 1 </win_probability>\n" +
+                    "\t\t\t<team_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 208.52 </total>\n" +
+                    "\t\t\t</team_points>\n" +
+                    "\t\t\t<team_projected_points>\n" +
+                    "\t\t\t\t<coverage_type> week </coverage_type>\n" +
+                    "\t\t\t\t<week> 16 </week>\n" +
+                    "\t\t\t\t<total> 131.00 </total>\n" +
+                    "\t\t\t</team_projected_points>\n" +
+                    "\t\t</team>\n" +
+                    "\t</teams>\n" +
+                    "</matchup>"
+        )
+
+        testPublishSubject.subscribeOn(testScheduler)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testPublishSubject.onComplete()
+        testScheduler.shutdown()
+    }
+
+    @Test
+    fun convertToMatchUpObjectFAAB() {
+        val testObserver = TestObserver.create<Pair<Team, Team>>()
+
+        testPublishSubject
+            .convertToMatchUpObject()
+            .subscribe(testObserver)
+        testPublishSubject.onNext(faabDocument)
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS)
+
+        testObserver.assertValueCount(1)
+        testObserver.assertValue {
+            it.first.faabBalance == 17 && it.second.faabBalance == 100
+        }
+    }
+
+    @Test
+    fun convertToMatchUpObjectNonFAAB() {
+        val testObserver = TestObserver.create<Pair<Team, Team>>()
+
+        testPublishSubject
+            .convertToMatchUpObject()
+            .subscribe(testObserver)
+        testPublishSubject.onNext(nonFaabDocument)
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS)
+
+        testObserver.assertValueCount(1)
+        testObserver.assertValue {
+            it.first.faabBalance == null && it.second.faabBalance == null
+        }
+    }
+
+    @Test
+    fun convertToMatchUpMessageFAAB() {
+        val testObserver = TestObserver.create<Message>()
+
+        testPublishSubject
+            .convertToMatchUpObject()
+            .convertToMatchUpMessage()
+            .subscribe(testObserver)
+        testPublishSubject.onNext(faabDocument)
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS)
+
+        testObserver.assertValueCount(1)
+        testObserver.assertValue { it is Message.MatchUp }
+        testObserver.assertValue {
+            it.message.contains("FAAB") && !it.message.contains("Waiver Priority")
+        }
+    }
+
+    @Test
+    fun convertToMatchUpMessageNonFAAB() {
+        val testObserver = TestObserver.create<Message>()
+
+        testPublishSubject
+            .convertToMatchUpObject()
+            .convertToMatchUpMessage()
+            .subscribe(testObserver)
+        testPublishSubject.onNext(nonFaabDocument)
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS)
+
+        testObserver.assertValueCount(1)
+        testObserver.assertValue { it is Message.MatchUp }
+        testObserver.assertValue {
+            it.message.contains("Waiver Priority") && !it.message.contains("FAAB")
+        }
+    }
+
+    @Test
+    fun convertToScoreUpdateMessage() {
+        val testObserver = TestObserver.create<Message>()
+
+        testPublishSubject
+            .convertToMatchUpObject()
+            .convertToScoreUpdateMessage()
+            .subscribe(testObserver)
+        testPublishSubject.onNext(faabDocument)
+        testScheduler.advanceTimeBy(50, TimeUnit.MILLISECONDS)
+
+        testObserver.assertValueCount(1)
+        testObserver.assertValue { it is Message.Score }
+        testObserver.assertValue {
+            it.message == "TEST TEAM 1 vs. TEST TEAM 2\\n" +
+                    "129.86 - 208.52"
+        }
+    }
+}


### PR DESCRIPTION
I’m on a non-auction league, so I’m not getting back anything in yahoo’s API for `faab_balance`. This meant I’m not getting any `MatchUp` or `ScoreUpdate` messages since it was erroring trying to convert the string to an int. 

So, this updates `team.faabBalance` to be nullable.

And then when composing the `MatchUp` message, I include FAAB balance if it’s non-null, and if it’s null instead include the waiver priority. ← Definitely up for recommendations on that, I felt like if you were auction, it was more important to have the balance, and the priority was only important for a tie breaker. Then if you aren’t an auction league, the most relevant info is the priority. But let me know if you disagree and I can update!

Tested by deploying to my heroku connected to my non-FAAB league, but I only have that one league for testing purposes.

Also feel free to provide any nits or any level of suggestions, I’m new to kotlin, so I’m sure there’s room for improvement. And didn’t see any contributing recommendations for styles, or PR format, etc.