### PR TITLE
Update ScoreUpdateJob Run Times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ hs_err_pid*
 
 # IntelliJ
 .idea/
+*.iml
 
 # CMake
 cmake-build-*/

--- a/bot/src/main/kotlin/bot/utils/Arbiter.kt
+++ b/bot/src/main/kotlin/bot/utils/Arbiter.kt
@@ -104,11 +104,10 @@ object Arbiter {
         // Times are in GMT since it is not effected by DST
 
         JobRunner.createJob(ScoreUpdateJob::class.java, "0 55 3 ? 9-1 FRI *")
-        JobRunner.createJob(ScoreUpdateJob::class.java, "0 00 17 ? 9-1 SUN *")
-        JobRunner.createJob(ScoreUpdateJob::class.java, "0 00 20 ? 9-1 SUN *")
-        JobRunner.createJob(ScoreUpdateJob::class.java, "0 00 0 ? 9-1 MON *")
-        JobRunner.createJob(ScoreUpdateJob::class.java, "0 55 3 ? 9-1 MON *")
-        JobRunner.createJob(ScoreUpdateJob::class.java, "0 55 3 ? 9-1 TUE *")
+        JobRunner.createJob(ScoreUpdateJob::class.java, "0 00 21 ? 9-1 SUN *")
+        JobRunner.createJob(ScoreUpdateJob::class.java, "0 00 1 ? 9-1 MON *")
+        JobRunner.createJob(ScoreUpdateJob::class.java, "0 30 4 ? 9-1 MON *")
+        JobRunner.createJob(ScoreUpdateJob::class.java, "0 30 4 ? 9-1 TUE *")
 
         JobRunner.runJobs()
     }


### PR DESCRIPTION
**What**
Updates following run times (PST) for ScoreUpdateJob:

- Remove Sunday at 9am
- Change Sunday at 12pm to 1pm
- Change Sunday at 4pm to 5pm
- Change Sunday at 7:55pm to 8:30pm
- Change Monday at 7:55pm to 8:30pm

**Why**
Bot is spamming a bit too much and to run jobs close to end of game