### PR TITLE
Add support for different sports leagues

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,6 +41,11 @@
       "value": "",
       "required": false
     },
+    "YAHOO_GAME_KEY": {
+      "description": "Yahoo Game Key: (NBA, NFL, MLB)",
+      "value": "",
+      "required": false
+    },
     "YAHOO_LEAGUE_ID": {
       "description": "Yahoo League ID",
       "value": "",

--- a/bot/src/main/kotlin/bot/utils/DataRetriever.kt
+++ b/bot/src/main/kotlin/bot/utils/DataRetriever.kt
@@ -18,7 +18,7 @@ object DataRetriever {
     private const val TRANSACTIONS = "/transactions"
 
     private val BASE_URL =
-        "https://fantasysports.yahooapis.com/fantasy/v2/league/nfl.l.${EnvVariables.YahooLeagueId.variable}"
+        "https://fantasysports.yahooapis.com/fantasy/v2/league/${EnvVariables.YahooGameKey.variable}.l.${EnvVariables.YahooLeagueId.variable}"
 
     private val oauthService = ServiceBuilder(EnvVariables.YahooClientId.variable)
         .apiSecret(EnvVariables.YahooClientSecret.variable)

--- a/shared/src/main/kotlin/shared/EnvVariables.kt
+++ b/shared/src/main/kotlin/shared/EnvVariables.kt
@@ -3,6 +3,7 @@ package shared
 sealed class EnvVariables(val variable: String?) {
     object YahooClientId : EnvVariables(System.getenv("YAHOO_CLIENT_ID"))
     object YahooClientSecret : EnvVariables(System.getenv("YAHOO_CLIENT_SECRET"))
+    object YahooGameKey : EnvVariables(System.getenv("YAHOO_GAME_KEY"))
     object YahooLeagueId : EnvVariables(System.getenv("YAHOO_LEAGUE_ID"))
     object GroupMeBotId : EnvVariables(System.getenv("GROUP_ME_BOT_ID"))
     object DiscordWebhookUrl : EnvVariables(System.getenv("DISCORD_WEBHOOK_URL"))


### PR DESCRIPTION
Each sport for Yahoo Fantasy has a [corresponding game key](https://developer.yahoo.com/fantasysports/guide/#description) for API calls so instead of hard coding it to `nfl` I added the ability for the user to input their own. 

I have [my fork](https://github.com/WhosNickDoglio/yahoo-fantasy-bot) working with my `nba` fantasy league, I _would imagine_ this would also work for `nhl` or `mlb` but haven't tested. 


Let me know if this was the correct way to do it, I really only have experience with Android so was just was just tinkering around with this. 






Resolves #49