### PR TITLE
Fixes #58

### DIFF
--- a/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
@@ -12,6 +12,7 @@ object GroupMe : MessagingService(MAX_MESSAGE_LENGTH) {
         EnvVariable.Str.GroupMeBotId.variable.let {
             println("Sending $NAME message...")
             val formatted = formatMessage(message);
+            println("TEST: {\"text\" : \"$formatted\"}, \"bot_id\" : \"$it\"}")
             val response = Unirest.post(URL)
                 .header("Content-Type", "application/json")
                 .body("{\"text\" : \"$formatted\"}, \"bot_id\" : \"$it\"}")

--- a/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
@@ -12,7 +12,6 @@ object GroupMe : MessagingService(MAX_MESSAGE_LENGTH) {
         EnvVariable.Str.GroupMeBotId.variable.let {
             println("Sending $NAME message...")
             val formatted = formatMessage(message);
-            println("TEST: {\"text\" : \"$formatted\"}, \"bot_id\" : \"$it\"}")
             val response = Unirest.post(URL)
                 .header("Content-Type", "application/json")
                 .body("{\"text\" : \"$formatted\"}, \"bot_id\" : \"$it\"}")

--- a/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
@@ -27,12 +27,14 @@ abstract class MessagingService(private val maxMessageLength: Int) : Consumer<St
     }
 
     private fun correctMessage(message: String): String {
+        val properJsonFormat = message.replace("\n", "\\n").replace("/", "\\/")
+
         return when {
-            message.startsWith("n") -> message.substring(1)
-            message.startsWith("\\") -> message.substring(1)
-            message.startsWith("\\n") -> message.substring(2)
-            message.endsWith("\\") -> message.substring(0, message.length)
-            message.endsWith("\\n") -> message.substring(0, message.length - 1)
+            properJsonFormat.startsWith("n") -> properJsonFormat.substring(1)
+            properJsonFormat.startsWith("\\") -> properJsonFormat.substring(1)
+            properJsonFormat.startsWith("\\n") -> properJsonFormat.substring(2)
+            properJsonFormat.endsWith("\\") -> properJsonFormat.substring(0, message.length)
+            properJsonFormat.endsWith("\\n") -> properJsonFormat.substring(0, message.length - 1)
             else -> message
         }.trim()
     }

--- a/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
@@ -35,7 +35,7 @@ abstract class MessagingService(private val maxMessageLength: Int) : Consumer<St
             properJsonFormat.startsWith("\\n") -> properJsonFormat.substring(2)
             properJsonFormat.endsWith("\\") -> properJsonFormat.substring(0, message.length)
             properJsonFormat.endsWith("\\n") -> properJsonFormat.substring(0, message.length - 1)
-            else -> message
+            else -> properJsonFormat
         }.trim()
     }
 }

--- a/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
@@ -27,7 +27,7 @@ abstract class MessagingService(private val maxMessageLength: Int) : Consumer<St
     }
 
     private fun correctMessage(message: String): String {
-        val properJsonFormat = message.replace("\n", "\\n").replace("/", "\\/")
+        val properJsonFormat = message.replace("\n", "\\n")
 
         return when {
             properJsonFormat.startsWith("n") -> properJsonFormat.substring(1)

--- a/bot/src/main/kotlin/bot/transformers/StandingsTransformer.kt
+++ b/bot/src/main/kotlin/bot/transformers/StandingsTransformer.kt
@@ -78,7 +78,7 @@ fun Observable<Element>.convertToStandingsMessage(): Observable<Message> =
             "> • FAAB: <b>$faab</b>"
         } ?: "> • Waiver Priority: <b>$waiverPriority</b>"}
         |${clinchedPlayoffs?.let { "> • Clinched?: <b>$clinchedPlayoffs</b>" }}
-        """.trimIndent()
+        """.trimMargin()
         )
     }
 
@@ -90,7 +90,7 @@ private fun generateTeamName(team: String, manager: String): String {
     } else {
         ""
     }}
-    """.trimIndent()
+    """.trimMargin()
 }
 
 private fun numberToEmoji(number: Int): String {

--- a/bot/src/main/kotlin/bot/transformers/TransactionDataTransformer.kt
+++ b/bot/src/main/kotlin/bot/transformers/TransactionDataTransformer.kt
@@ -31,7 +31,7 @@ private fun addMessage(event: Element): Message {
         """
             |<b>$fantasyTeam</b>
             |Added: ${getPlayerInfo(event)}
-        """.trimIndent()
+        """.trimMargin()
     )
 }
 
@@ -42,7 +42,7 @@ private fun dropMessage(event: Element): Message {
         """
             |<b>$fantasyTeam</b>
             |Dropped: ${getPlayerInfo(event)}
-        """.trimIndent()
+        """.trimMargin()
     )
 }
 
@@ -77,7 +77,7 @@ private fun addDropMessage(event: Element): Message {
             |<b>$fantasyTeam</b>
             |Added: ${playersAdded.trimEnd().removeSuffix(",")}
             |Dropped: ${playersDropped.trimEnd().removeSuffix(",")}
-        """.trimIndent()
+        """.trimMargin()
     )
 }
 
@@ -112,7 +112,7 @@ private fun tradeMessage(event: Element): Message {
         """
             |<b>$trader</b> traded: $finalMessageFromTradee
             |<b>$tradee</b> traded: $finalMessageFromTrader
-        """.trimIndent()
+        """.trimMargin()
     )
 }
 

--- a/bot/src/main/kotlin/bot/utils/Arbiter.kt
+++ b/bot/src/main/kotlin/bot/utils/Arbiter.kt
@@ -49,7 +49,7 @@ object Arbiter {
                     """
                         |Hey there! I am the Yahoo Fantasy Bot that notifies you about all things happening in your league!
                         |Star me on Github: https://github.com/landonp1203/yahoo-fantasy-bot
-                    """.trimIndent()
+                    """.trimMargin()
                 )
             )
             Postgres.markStartupMessageReceived()


### PR DESCRIPTION
- Fixes kotlinizatiojn updates from before when sending messages
- Now uses proper trim method (`trimMargin()` instead of `trimIndent()`) to remove `|` character from messages